### PR TITLE
CSV Bugfix

### DIFF
--- a/KTAB/kmodel/csvparser/csv_parser.cpp
+++ b/KTAB/kmodel/csvparser/csv_parser.cpp
@@ -106,7 +106,7 @@ std::string csv_parser::get_value(int row,int column)
       rit=line.rbegin();
       while (*rit!=',')
   {
-    value += *rit;
+	value = *rit + value;
     rit++;
   }
       return value;

--- a/KTAB/kmodel/csvparser/csv_parser.cpp
+++ b/KTAB/kmodel/csvparser/csv_parser.cpp
@@ -106,7 +106,7 @@ std::string csv_parser::get_value(int row,int column)
       rit=line.rbegin();
       while (*rit!=',')
   {
-	value = *rit + value;
+    value = *rit + value;
     rit++;
   }
       return value;


### PR DESCRIPTION
When using the reverse iterator on the last column, we must build the string from back to front to avoid reversed output.