### PR TITLE
Correct  premature ending of sqlite transaction

### DIFF
--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1602,8 +1602,8 @@ void SMPModel::populateSpatialSalienceTable(bool sqlP) const {
                 }
             }
         }
-        sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     }
+    sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     return;
 }
 //Populate the actor description table


### PR DESCRIPTION
In populateSpatialSalienceTable(), only a single sqlite transaction is manually started, to cover output for all turns. In line with that, the manual ending of the transaction should occur after all turn output is completed, not after each turn's output.