### PR TITLE
Fix SQLite Resource Leaks

### DIFF
--- a/KTAB/kmodel/libsrc/kmodelsql.cpp
+++ b/KTAB/kmodel/libsrc/kmodelsql.cpp
@@ -365,6 +365,7 @@ void Model::sqlAUtil(unsigned int t) {
         }
     }
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
     delete sqlBuff;
@@ -420,6 +421,7 @@ void Model::sqlPosEquiv(unsigned int t)
     }
     // end databse transaction
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
     delete sqlBuff;
     sqlBuff = nullptr;
@@ -478,6 +480,7 @@ void Model::sqlPosProb(unsigned int t) {
         }
     }
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
     delete sqlBuff;
@@ -552,6 +555,7 @@ void Model::sqlPosVote(unsigned int t) {
         }
     }
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
     delete sqlBuff;

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -663,6 +663,10 @@ SMPState* SMPState::doBCN() const {
 			rowtoupdate = sqlite3_prepare_v2(db, "select MAX(Bargn_i) from Bargn", -1, &stmt, NULL);
 			rc = sqlite3_step(stmt);
 			lastRowinserted = sqlite3_column_int(stmt, 0);
+            
+            // finalize statement to avoid resource leaks
+            sqlite3_finalize(stmt);
+            stmt = nullptr;
 
 			// prepare the sql statement to insert
 			for (int bgnlop = 0; bgnlop < brgnIIJ->posInit.numR(); bgnlop++)
@@ -693,6 +697,10 @@ SMPState* SMPState::doBCN() const {
 			rc = sqlite3_step(stmt);
 			lastRowinserted = sqlite3_column_int(stmt, 0);
 
+            // finalize statement to avoid resource leaks
+            sqlite3_finalize(stmt);
+            stmt = nullptr;
+
 			for (int bgnlop = 0; bgnlop < brgnIIJ->posRcvr.numR(); bgnlop++)
 			{
 				// prepare the sql statement to insert
@@ -722,6 +730,10 @@ SMPState* SMPState::doBCN() const {
 			rc = sqlite3_step(stmt);
 			lastRowinserted = sqlite3_column_int(stmt, 0);
 
+            // finalize statement to avoid resource leaks
+            sqlite3_finalize(stmt);
+            stmt = nullptr;
+
 			for (int bgnlop = 0; bgnlop < brgnJIJ->posInit.numR(); bgnlop++)
 			{
 				// prepare the sql statement to insert
@@ -749,6 +761,10 @@ SMPState* SMPState::doBCN() const {
 			rowtoupdate = sqlite3_prepare_v2(db, "select MAX(Bargn_i) from Bargn", -1, &stmt, NULL);
 			rc = sqlite3_step(stmt);
 			lastRowinserted = sqlite3_column_int(stmt, 0);
+            
+            // finalize statement to avoid resource leaks
+            sqlite3_finalize(stmt);
+            stmt = nullptr;
 
 			for (int bgnlop = 0; bgnlop < brgnJIJ->posRcvr.numR(); bgnlop++)
 			{
@@ -908,6 +924,11 @@ SMPState* SMPState::doBCN() const {
 		rowtoupdate = sqlite3_prepare_v2(db, sqlBuff, -1, &stmt, NULL);
 		rc = sqlite3_step(stmt);
 		lastRowinserted = sqlite3_column_int(stmt, 0);
+
+        // finalize statement to avoid resource leaks
+        sqlite3_finalize(stmt);
+        stmt = nullptr;
+
 		for (int bgnlop = 0; bgnlop < w.numC(); bgnlop++)
 		{
 			memset(sql2Buff, '\0', 200);
@@ -1192,6 +1213,7 @@ tuple<double, double> SMPState::probEduChlg(unsigned int h, unsigned int k, unsi
     sqlite3_exec(db, sqlBuff, NULL, NULL, &zErrMsg);
 */
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
     delete sqlBuff;
@@ -1469,6 +1491,7 @@ void SMPModel::showVPHistory(bool sqlP) const {
     }
 
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     cout << endl;
 
     // show probabilities over time.
@@ -1552,6 +1575,7 @@ void SMPModel::populateSpatialCapabilityTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 //Populates the SpatialSliencetable
@@ -1610,6 +1634,7 @@ void SMPModel::populateSpatialSalienceTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 //Populate the actor description table
@@ -1652,6 +1677,7 @@ void SMPModel::populateActorDescriptionTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 SMPModel * SMPModel::readCSV(string fName, PRNG * rng) {

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1290,7 +1290,13 @@ SMPModel::~SMPModel() {
 
     if (nullptr != smpDB) {
         cout << "SMPModel::~SMPModel Closing database" << endl << flush;
-        sqlite3_close(smpDB);
+        int close_result = sqlite3_close(smpDB);
+        if (close_result != SQLITE_OK) {
+            cout << "SMPModel::~SMPModel Closing database failed!" << endl << flush;
+        }
+        else {
+            cout << "SMPModel::~SMPModel Closing database succeeded." << endl << flush;
+        }
         smpDB = nullptr;
     }
 


### PR DESCRIPTION
As described in the SQLite3 documentation for [Prepared Statement Object](https://www.sqlite.org/c3ref/stmt.html) and [Destroy A Prepared Statement Object](https://www.sqlite.org/c3ref/finalize.html), to avoid resource leaks, each prepared statement object should be finalized once it is no longer needed. Without this, the database will not be able to be closed.

Here, I provide command line output as to the success or failure of the database closure in SMPC, and insert the necessary `sqlite3_finalize()` calls to prevent resource leaks and allow for successful database closure.

Note that if a given prepared statement pointer is re-used (such as the re-use of `stmt` in `SMPState::doBCN()`), there must be a `sqlite3_finalize()` call before each new `sqlite3_prepare_v2()` call to avoid leaks.