### PR TITLE
Fix SQLite Resource Leaks (Round 2)

### DIFF
--- a/KTAB/kmodel/libsrc/kmodelsql.cpp
+++ b/KTAB/kmodel/libsrc/kmodelsql.cpp
@@ -495,6 +495,7 @@ void Model::sqlUpdateBargainTable (unsigned int t,   double IntProb, int Init_Se
 	assert(SQLITE_OK == rslt);
 
 	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
 	printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
 	delete sqlBuff;
@@ -549,6 +550,7 @@ void Model::sqlBargainEntries(unsigned int t, int bargainId, int Baragainer, int
 	assert(SQLITE_OK == rslt);
 
 	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
 	printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
 	delete sqlBuff;
@@ -616,6 +618,7 @@ void Model::sqlBargainValue(unsigned int t, int Baragainer, int Dim, KBase::Vctr
 	assert(SQLITE_OK == rslt);
 	
 	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
  
 
 	delete sqlBuff;
@@ -677,7 +680,7 @@ void Model::sqlBargainUtil(unsigned int t, int Bargn_i,  KBase::KMatrix Util_mat
 	}
 
 	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
-
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
 
 	delete sqlBuff;
 	sqlBuff = nullptr;
@@ -721,6 +724,7 @@ void Model::sqlScenarioDesc(const char *ScenName)
 	//rslt = sqlite3_reset(insStmt);
 	//assert(SQLITE_OK == rslt);
  	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
  
 	delete sqlBuff;
 	sqlBuff = nullptr;
@@ -785,7 +789,7 @@ void Model::sqlBargainVote(unsigned int t, int Bargn_i, int Bargn_j, KBase::KMat
 	}
 
 	sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
-
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
 
 	delete sqlBuff;
 	sqlBuff = nullptr;

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1158,7 +1158,13 @@ SMPModel::~SMPModel() {
 
     if (nullptr != smpDB) {
         cout << "SMPModel::~SMPModel Closing database" << endl << flush;
-        sqlite3_close(smpDB);
+        int close_result = sqlite3_close(smpDB);
+        if (close_result != SQLITE_OK) {
+            cout << "SMPModel::~SMPModel Closing database failed!" << endl << flush;
+        }
+        else {
+            cout << "SMPModel::~SMPModel Closing database succeeded." << endl << flush;
+        }
         smpDB = nullptr;
     }
 

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1060,6 +1060,7 @@ tuple<double, double> SMPState::probEduChlg(unsigned int h, unsigned int k, unsi
     sqlite3_exec(db, sqlBuff, NULL, NULL, &zErrMsg);
 */
     sqlite3_exec(db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     printf("Stored SQL for turn %u of all estimators, actors, and positions \n", t);
 
     delete sqlBuff;
@@ -1337,6 +1338,7 @@ void SMPModel::showVPHistory(bool sqlP) const {
     }
 
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     cout << endl;
 
     // show probabilities over time.
@@ -1420,6 +1422,7 @@ void SMPModel::populateSpatialCapabilityTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 //Populates the SpatialSliencetable
@@ -1478,6 +1481,7 @@ void SMPModel::populateSpatialSalienceTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 //Populate the actor description table
@@ -1520,6 +1524,7 @@ void SMPModel::populateActorDescriptionTable(bool sqlP) const {
         }
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     return;
 }
 SMPModel * SMPModel::readCSV(string fName, PRNG * rng) {


### PR DESCRIPTION
Repeating and extending the changes from [Pull 4](https://github.com/KAPSARC/KTAB/pull/4), as they appear to have been lost in subsequent merges.

As stated in the earlier pull:

> As described in the SQLite3 documentation for Prepared Statement Object and Destroy A Prepared Statement Object, to avoid resource leaks, each prepared statement object should be finalized once it is no longer needed. Without this, the database will not be able to be closed.
> 
> Here, I provide command line output as to the success or failure of the database closure in SMPC, and insert the necessary sqlite3_finalize() calls to prevent resource leaks and allow for successful database closure.