### PR TITLE
Fix memory leaks

### DIFF
--- a/KTAB/kmodel/libsrc/kmodel.cpp
+++ b/KTAB/kmodel/libsrc/kmodel.cpp
@@ -53,6 +53,8 @@ Model::Model(PRNG * r, string desc) {
         std::strftime(utcBuff, 150, "Scenario-UTC-%Y-%m-%d-%H%M-%S", gmtime(&start_time));
         cout << "Generating default name from UTC start time" << endl << flush;
         scenName = utcBuff;
+        delete utcBuff;
+        utcBuff = nullptr;
     }
     else
     {

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1493,7 +1493,7 @@ void SMPModel::populateActorDescriptionTable(bool sqlP) const {
 }
 SMPModel * SMPModel::readCSV(string fName, PRNG * rng) {
     using KBase::KException;
-    char * errBuff = newChars(100); // as sprintf requires
+    char * errBuff; // as sprintf requires
     csv_parser csv(fName);
     // Get values according to row number and column number.
     // Remember it starts from (1,1) and not (0,0)

--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -1220,6 +1220,8 @@ void SMPModel::sankeyOutput(string inputCSV) const {
         fclose(f1);
         f1 = nullptr;
         cout << "done" << endl;
+        delete epName;
+        epName = nullptr;
 
         const char* appendPosLog = "_posLog.csv";
         char* plName = newChars(nameLen + strlen(appendPosLog) + 1);
@@ -1241,6 +1243,8 @@ void SMPModel::sankeyOutput(string inputCSV) const {
         fclose(f2);
         f2 = nullptr;
         cout << "done." << endl;
+        delete plName;
+        plName = nullptr;
     }
     return;
 }
@@ -1304,6 +1308,9 @@ void SMPModel::showVPHistory(bool sqlP) const {
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
     cout << endl;
+
+    delete sqlBuff;
+    sqlBuff = nullptr;
 
     // show probabilities over time.
     // Note that we have to set the aUtil matrices for the last one.
@@ -1387,6 +1394,10 @@ void SMPModel::populateSpatialCapabilityTable(bool sqlP) const {
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
+
+    delete sqlBuff;
+    sqlBuff = nullptr;
+
     return;
 }
 //Populates the SpatialSliencetable
@@ -1446,6 +1457,10 @@ void SMPModel::populateSpatialSalienceTable(bool sqlP) const {
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
+
+    delete sqlBuff;
+    sqlBuff = nullptr;
+
     return;
 }
 //Populate the actor description table
@@ -1489,6 +1504,10 @@ void SMPModel::populateActorDescriptionTable(bool sqlP) const {
     }
     sqlite3_exec(smpDB, "END TRANSACTION", NULL, NULL, &zErrMsg);
     sqlite3_finalize(insStmt); // finalize statement to avoid resource leaks
+
+    delete sqlBuff;
+    sqlBuff = nullptr;
+
     return;
 }
 SMPModel * SMPModel::readCSV(string fName, PRNG * rng) {

--- a/examples/smp/libsrc/smpsql.cpp
+++ b/examples/smp/libsrc/smpsql.cpp
@@ -154,6 +154,7 @@ void SMPModel::sqlTest() {
         sprintf(buff, "Created SMPModel table %u successfully \n", i);
         sql = SMPModel::createSQL(i);
         sExec(sql, buff); // ignore return-code
+        delete buff;
         buff = nullptr;
         cout << flush;
     }

--- a/examples/smp/src/demosmp.cpp
+++ b/examples/smp/src/demosmp.cpp
@@ -251,6 +251,7 @@ namespace DemoSMP {
     cout << endl;
     cout << "Delete model (actors, states, positions, etc.)" << endl << flush;
 
+    delete md0;
     md0 = nullptr;
 
     return;

--- a/examples/smp/src/demosmp.cpp
+++ b/examples/smp/src/demosmp.cpp
@@ -121,6 +121,8 @@ namespace DemoSMP {
       auto buff = KBase::newChars(100);
       sprintf(buff, "SDim-%02u", i);
       md0->addDim(buff);
+      delete buff;
+      buff = nullptr;
     }
     assert(sDim == md0->numDim);
 


### PR DESCRIPTION
Deleting c-style strings and one instance of SMPModel after usage, to prevent memory leaks.

When using c-style strings, keep in mind that assigning a c-style string to a `std::string` makes a copy (as documented [here](http://www.cplusplus.com/reference/string/string/assign/)), so after that assignment the source c-style string may be safely deleted.