### PR TITLE
added more logging and switches to control SQL logging

### DIFF
--- a/KTAB/kmodel/libsrc/kmodelsql.cpp
+++ b/KTAB/kmodel/libsrc/kmodelsql.cpp
@@ -558,8 +558,10 @@ namespace KBase {
     smpDB = db;
   }
 
-  void Model::sqlBargainValue(unsigned int t, int Baragainer, int Dim, KBase::VctrPstn Coord)
-  {
+  void Model::sqlBargainValue(unsigned int t, int Baragainer, int Dim, KBase::VctrPstn Coord) {
+
+    // TODO: fix this up to cycle through the dimensions of the received points
+
     // initiate the database
     sqlite3 * db = smpDB;
 
@@ -603,7 +605,7 @@ namespace KBase {
     if (bk > 1)
       rslt = sqlite3_bind_double(insStmt, 5, Coord(1, 0));
     else
-      rslt = sqlite3_bind_double(insStmt, 5, 0.0);
+      rslt = sqlite3_bind_double(insStmt, 5, 0.0); 
 
     assert(SQLITE_OK == rslt);
 

--- a/examples/smp/libsrc/smp.h
+++ b/examples/smp/libsrc/smp.h
@@ -196,11 +196,12 @@ protected:
     SMPState* doBCN() const;
     
 
-    // returns estimated probability k wins (given likely coaltiions), and expected delta-util of that challenge
-    tuple<double, double> probEduChlg(unsigned int h, unsigned int k, unsigned int i, unsigned int j) const;
+    // returns estimated probability k wins (given likely coaltiions), and expected delta-util of that challenge.
+    // If desired, record in SQLite.
+    tuple<double, double> probEduChlg(unsigned int h, unsigned int k, unsigned int i, unsigned int j, bool sqlP) const;
 
     // return best j, p[i>j], edu[i->j]
-    tuple<int, double, double> bestChallenge(unsigned int i) const;
+    tuple<int, double, double> bestChallenge(unsigned int i, bool sqlP) const;
     
     // the actor's ideal, against which they judge others' positions
     vector<VctrPstn> ideals = {};


### PR DESCRIPTION
- The SQL logging switches will be needed in the future to limit SQL logging during monte carlo and sensitivity analysis. 
- The extra logging information is part of what will be necessary to support alternative bargaining models.