### PR TITLE
Reimplement Non-duplicative Checking (#142)

### DIFF
--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -524,8 +524,6 @@ double SMPState::aNRA(unsigned int i) const {
   return ri;
 }
 
-
-
 void  SMPState::setAccomodate(const KMatrix & aMat) {
   const unsigned int na = model->numAct;
   assert(Model::minNumActor <= na);
@@ -533,6 +531,7 @@ void  SMPState::setAccomodate(const KMatrix & aMat) {
   assert(na == aMat.numR());
   assert(na == aMat.numC());
   accomodate = aMat;
+  identAccMat = KBase::iMatP(accomodate);
   return;
 }
 
@@ -545,7 +544,6 @@ void SMPState::addPstn(Position* ap) {
   State::addPstn(ap);
   return;
 }
-
 
 bool SMPState::equivNdx(unsigned int i, unsigned int j) const {
   /// Compare two actual positions in the current state

--- a/examples/smp/libsrc/smpbcn.cpp
+++ b/examples/smp/libsrc/smpbcn.cpp
@@ -641,7 +641,7 @@ tuple<double, double> SMPState::probEduChlg(unsigned int h, unsigned int k, unsi
   // h's estimate of i's unilateral influence contribution to (i:j).
   // When ideals perfectly track positions, this must be positive
   double contrib_i_ij = Model::vote(vr, si*ci, uii, uij);
-  if (KBase::iMatP(accomodate)) {
+  if (identAccMat) {
     assert(0 <= contrib_i_ij);
   }
   // If not, you could have the ordering (Idl_i, Pos_j, Pos_i)
@@ -651,7 +651,7 @@ tuple<double, double> SMPState::probEduChlg(unsigned int h, unsigned int k, unsi
   // h's estimate of j's unilateral influence contribution to (i:j).
   // When ideals perfectly track positions, this must be negative
   double contrib_j_ij = Model::vote(vr, sj*cj, uji, ujj);
-  if (KBase::iMatP(accomodate)) {
+  if (identAccMat) {
     assert(contrib_j_ij <= 0);
   }
   // Similarly, you could have an ordering like (Idl_j, Pos_i, Pos_j)


### PR DESCRIPTION
The changes in Pmat2 (#111) that prevented frequent re-checking of the Accomodation Matrix, were unintentionaly undone.  This commit re-implements them.