### PR TITLE
SMPState::pDist() voting rule fix (alternate-testing)

### DIFF
--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -742,7 +742,8 @@ tuple< KMatrix, VUI> SMPState::pDist(int persp) const {
     /// Calculate the probability distribution over states from this perspective
 
     // TODO: convert this to a single, commonly used setup function
-    const VotingRule vr = VotingRule::Proportional;
+    auto smod = (const SMPModel*)model;
+    const VotingRule vr = smod->vrCltn;
     const ReportingLevel rl = ReportingLevel::Silent;
 
     const unsigned int na = model->numAct;


### PR DESCRIPTION
In SMPState::setAllAUtil(), the voting rule used for utility calculation is the smod->vrCltn member of the SMPModel object. However, in SMPState::pDist(), the voting rule is fixed to a value of VotingRule::Proportional. Should not the voting rule used in these two calculations be the same?

This commit updates SMPState::pDist() to also use the smod->vrCltn member to determine the voting rule used.