### PR TITLE
handle "--std=c++11" the same way as the rest of KTAB

### DIFF
--- a/easyloggingpp/CMakeLists.txt
+++ b/easyloggingpp/CMakeLists.txt
@@ -1,3 +1,7 @@
+# --------------------------------------------
+# Copyright KAPSARC. Open source MIT License.
+# --------------------------------------------
+
 cmake_minimum_required(VERSION 2.8.12)
 
 project(Easyloggingpp CXX)
@@ -89,3 +93,10 @@ if (test)
 
     add_test(NAME easyloggingppUnitTests COMMAND easyloggingpp-unit-tests -v)
 endif()
+# --------------------------------------------
+if (UNIX OR MINGW)
+	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif(UNIX OR MINGW)
+# --------------------------------------------
+# Copyright KAPSARC. Open source MIT License.
+# --------------------------------------------


### PR DESCRIPTION
Added copyright header and footer. Specify C++11 standard for Linux.

This changes this CMakeLists.txt file to handle the C++11 standard for Linux in the same way as other CMakeLists.txt file in the KTAB system: agenda, comsel, minwater, pmatrix, reformpri, smp, kmodel, and kutils.

 The macro to detect standards did not appear to work with OpenSUSE Tumbleweed.