### PR TITLE
extern c api to configure and run smp model from a shared lib

### DIFF
--- a/examples/smp/libsrc/smp.cpp
+++ b/examples/smp/libsrc/smp.cpp
@@ -31,6 +31,52 @@
 #include <QSqlError>
 #include <QSqlRecord>
 
+extern "C" {
+  void configLogger(const char *cfgFile) {
+    if (nullptr != cfgFile) {
+      KBase::Model::configLogger(cfgFile);
+    }
+  }
+
+  void dbLoginCredentials(const char *connStr) {
+    if (nullptr != connStr) {
+      KBase::Model::loginCredentials(std::string(connStr));
+    }
+  }
+
+  const char* runSmpModel(unsigned int sqlLogFlags[5], const char* inputDataFile,
+    unsigned int seed, unsigned int saveHistory, int modelParams[9] = 0) {
+
+    std::vector<bool> sqlFlags;
+    for (unsigned int i = 0; i < 5; ++i) {
+      if (0 == sqlLogFlags[i]) {
+        sqlFlags.push_back(false);
+      }
+      else {
+        sqlFlags.push_back(true);
+      }
+    }
+
+    bool saveHist = false;
+    if (0 != saveHistory) {
+      saveHist = true;
+    }
+
+    std::vector<int> modelParameters;
+    if (modelParams) {
+      for (unsigned int i = 0; i < 9; ++i) {
+        modelParameters.push_back(modelParams[i]);
+      }
+    }
+
+    std::string scenarioID = SMPLib::SMPModel::runModel(
+      sqlFlags, std::string(inputDataFile), seed, saveHist, modelParameters
+    );
+
+    return scenarioID.c_str();
+  }
+}
+
 namespace SMPLib {
 using std::function;
 using std::get;


### PR DESCRIPTION
Following three new APIs under extern C to facilitate the smp model run by dynamically loading the smp shared library:

// Function configures the Easylogging++ using a config file
void configLogger(const char *cfgFile)

// Function takes the connection string for a db
void dbLoginCredentials(const char *connStr)

// Function to run the smp model
const char* runSmpModel(unsigned int sqlLogFlags[5], const char* inputDataFile,  unsigned int seed, unsigned int saveHistory, int modelParams[9] = 0)