### PR TITLE
Resubmit CI update and edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,6 @@ before_install:
 
 install:
 #Linux Prerequisites 
-  - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get --allow-unauthenticated upgrade #Allow unuthenticated for llvm-toolchain-trusty
   - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get install qt5-default; fi #install Qt5 libraries
   - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo bash ./install-linux-deps.sh; fi  # Why do I need permission?
 #OS X Prerequisties  

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,23 @@ matrix:
         - C_COMPILER=gcc-6
         - CXX_COMPILER=g++-6
         
+         - os: linux
+      dist: trusty
+      compiler: gcc
+      branches:
+        only:
+          - master
+          - testing
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6.3
+      env:
+        - C_COMPILER=gcc-6.3
+        - CXX_COMPILER=g++-6.3
+        
     - os: linux
       dist: trusty
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,8 @@ matrix:
       env:
         - C_COMPILER=clang-3.6
         - CXX_COMPILER=clang++-3.6
+        
 before_install:  
-  - if [[ $TRAVIS_OS_NAME == linux]]; then sudo apt-get install gcc-6 g++-6; fi
    # necessary because Travis overwrites CXX and CC!
   - if [[ $TRAVIS_OS_NAME == linux ]]; then export CXX=$CXX_COMPILER CC=$C_COMPILER; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,9 @@ matrix:
       env:
         - C_COMPILER=clang-3.6
         - CXX_COMPILER=clang++-3.6
-before_install:  # necessary because Travis overwrites CXX and CC!
+before_install:  
+  - if [[ $TRAVIS_OS_NAME == linux && C_COMPILER == gcc-6.3 && CXX_COMPILER == g++-6.3]]; then sudo apt-get install gcc-6.3 g++-6.3; fi
+   # necessary because Travis overwrites CXX and CC!
   - if [[ $TRAVIS_OS_NAME == linux ]]; then export CXX=$CXX_COMPILER CC=$C_COMPILER; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
         - C_COMPILER=gcc-6
         - CXX_COMPILER=g++-6
         
-         - os: linux
+    - os: linux
       dist: trusty
       compiler: gcc
       branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,11 +114,12 @@ matrix:
         - CXX_COMPILER=clang++-3.6
         
 before_install:  
-   # necessary because Travis overwrites CXX and CC!
+   # necessary because Travis overwrites CXX and CC!   
   - if [[ $TRAVIS_OS_NAME == linux ]]; then export CXX=$CXX_COMPILER CC=$C_COMPILER; fi
 
 install:
 #Linux Prerequisites 
+  - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get --allow-unauthenticated upgrade #Allow unuthenticated for llvm-toolchain-trusty
   - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get install qt5-default; fi #install Qt5 libraries
   - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo bash ./install-linux-deps.sh; fi  # Why do I need permission?
 #OS X Prerequisties  

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.5 main"
+            - llvm-toolchain-precise-3.5
           packages:
             - g++-4.9
             - clang-3.5
@@ -105,7 +105,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.6 main"
+            - llvm-toolchain-precise-3.6
           packages:
             - g++-4.9
             - clang-3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,10 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-6.3
+            - g++-7
       env:
-        - C_COMPILER=gcc-6.3
-        - CXX_COMPILER=g++-6.3
+        - C_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
         
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
         - C_COMPILER=clang-3.6
         - CXX_COMPILER=clang++-3.6
 before_install:  
-  - if [[ $TRAVIS_OS_NAME == linux && C_COMPILER == gcc-6.3 && CXX_COMPILER == g++-6.3]]; then sudo apt-get install gcc-6.3 g++-6.3; fi
+  - if [[ $TRAVIS_OS_NAME == linux]]; then sudo apt-get install gcc-6 g++-6; fi
    # necessary because Travis overwrites CXX and CC!
   - if [[ $TRAVIS_OS_NAME == linux ]]; then export CXX=$CXX_COMPILER CC=$C_COMPILER; fi
 

--- a/install-linux-deps.sh
+++ b/install-linux-deps.sh
@@ -6,3 +6,5 @@ add-apt-repository -y ppa:george-edison55/cmake-3.x
 apt-get update --assume-yes
 apt-get install --assume-yes cmake
 cmake --version  # This allows us to confirm which version of cmake has been installed.
+
+apt-get --allow-unauthenticated upgrade

--- a/install-linux-deps.sh
+++ b/install-linux-deps.sh
@@ -6,5 +6,3 @@ add-apt-repository -y ppa:george-edison55/cmake-3.x
 apt-get update --assume-yes
 apt-get install --assume-yes cmake
 cmake --version  # This allows us to confirm which version of cmake has been installed.
-
-apt-get --allow-unauthenticated upgrade


### PR DESCRIPTION
1- Replaced the llvm-toolchain-trusty to llvm-toolchain-precise due to a package unauthenticated issue that prevented the Clang test from proceeding.

2- Added gcc-7/g++-7 to the test.